### PR TITLE
don't dereference and free buffer if there have been some kind of errors while reading

### DIFF
--- a/rc522.c
+++ b/rc522.c
@@ -84,6 +84,10 @@ static uint8_t* rc522_read_n(rc522_handle_t rc522, uint8_t addr, uint8_t n)
 static inline uint8_t rc522_read(rc522_handle_t rc522, uint8_t addr)
 {
     uint8_t* buffer = rc522_read_n(rc522, addr, 1);
+
+    // If buffer is NULL, it's already freed and also we don't want to dereference it, so just returning some value indicating that there are some errors. All functions using this should check if return value equal to that
+    if (buffer == NULL) return 0;
+
     uint8_t res = buffer[0];
     free(buffer);
 


### PR DESCRIPTION
This library performs read/write test to check if RFID-RC522 connected to the board. However, read function performs NULL dereference and tries to free already freed buffer, leading to core panic. This PR adds a little check that prevents such behaviour and allows ESP32 to continue execution even in case of any errors. While this isn't complete solution for recovery after errors, at very least this allows to remotely manipulate ESP32 and implement additional checks, do something if problems are detected and increases overall system stability.

Edited: This PR:
Fixes #18
Fixes #19 
Fixes #21 