### PR TITLE
Fix rc522 resources deallocation if not connected.

### DIFF
--- a/rc522.c
+++ b/rc522.c
@@ -441,6 +441,10 @@ esp_err_t rc522_start(rc522_handle_t rc522)
             if((err = rc522_write(rc522, test_addr, i)) != ESP_OK || rc522_read(rc522, test_addr) != i) {
                 ESP_LOGE(TAG, "Read/write test failed");
                 rc522_destroy(rc522);
+                
+                // ensure return of error even when failure of read test only.
+                if (err == ESP_OK) err = ESP_ERR_INVALID_STATE ;
+
                 return err;
             }
         }

--- a/rc522.c
+++ b/rc522.c
@@ -84,6 +84,10 @@ static uint8_t* rc522_read_n(rc522_handle_t rc522, uint8_t addr, uint8_t n)
 static inline uint8_t rc522_read(rc522_handle_t rc522, uint8_t addr)
 {
     uint8_t* buffer = rc522_read_n(rc522, addr, 1);
+
+    // If buffer is NULL, it's already freed and also we don't want to dereference it, so just returning some value indicating that there are some errors. All functions using this should check if return value equal to that
+    if (buffer == NULL) return 0;
+
     uint8_t res = buffer[0];
     free(buffer);
 

--- a/rc522.h
+++ b/rc522.h
@@ -19,7 +19,8 @@ extern "C" {
 
 ESP_EVENT_DECLARE_BASE(RC522_EVENTS);
 
-typedef struct rc522* rc522_handle_t;
+typedef struct rc522 rc522 ;
+typedef rc522* rc522_handle_t;
 
 typedef enum {
     RC522_TRANSPORT_SPI,

--- a/rc522.h
+++ b/rc522.h
@@ -112,8 +112,10 @@ esp_err_t rc522_pause(rc522_handle_t rc522);
 /**
  * @brief Destroy RC522 and free all resources. Cannot be called from event handler.
  * @param rc522 Handle
+ * 
+ * Pointer to rc522_handle_t is required inorder to free rc522_handle_t itself.
  */
-void rc522_destroy(rc522_handle_t rc522);
+void rc522_destroy(rc522_handle_t* rc522);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The problem is with the pessimistic route of the library. Some errors aren't propagated properly and the deallocation of resources seems undocumented. When the problem occurs there are many logs stating failure to determine the transport type followed by read/write failure stating ESP_ERR_INVALID_STATE and ultimately a core panic.

When mrfc522 isn't connected to esp32, the write succeeds but there is read failure. The read failure prompts the library to delete the rc522 reference but this isn't documented anywhere and the returned scanner immediately becomes invalid.  This would be okay if all other resources are properly deallocated and associated event handlers are correctly removed.

Also, only read failures on the initial r/w test return ESP_OK which makes the callers assume that rc522 scanner properly started.  Any subsequent event handlers try to handle events for an unstarted rc522 scanner which created many invalid reference deallocations.

The destroy function to remove the rc522 reference created by the rc522_create(...) function fails to properly destroy the associated rc522.  I figured that the library was trying to delete rc522 on the initial r/w test failure for which a pointer reference to the stored rc522 pointer is required which wasn't set properly. 

Despite these fixes, there is still a problem in some instances ( without any other changes ). 

I also have a few questions:
- Does the library handle all the deallocations or deallocation of resources to be done by library users ? ( For this I assume  the library does all the necessary deallocation on failures to avoid any sort of runtime errors)
- Do the connected event handlers automatically get removed on fatal errors? (Errors like invalid transport type and null rc522 reference)