### PR TITLE
Change logic of freeing of SPI bus to when not initialized by user.

### DIFF
--- a/rc522.c
+++ b/rc522.c
@@ -479,7 +479,7 @@ static void rc522_destroy_transport(rc522_handle_t rc522)
     switch(rc522->config->transport) {
         case RC522_TRANSPORT_SPI:
             spi_bus_remove_device(rc522->spi_handle);
-            if(rc522->bus_initialized_by_user) {
+            if(!rc522->bus_initialized_by_user){
                 spi_bus_free(rc522->config->spi.host);
             }
             break;


### PR DESCRIPTION
I think this is the fix for issue #21. The logic is to free the SPI bus when it was initialized by the library itself which happens when bus_initialized_by_use is false. 

The assertion failure is the result of the library trying to free the SPI bus when other clients are still connected (Determined by Chip Selects).

There are still other errors when connected with AI-thinker esp32cam. Both SD card and rc522 are in SPI mode, the initialization succeeds but there is a panic stating  `StoreProhibited` ( I will open up a different issue for that, as I am not sure if I am doing things wrong, esp32cam is causing the error or rc522 library itself). 