### PR TITLE
Return `esp_err_t` from all functions

### DIFF
--- a/rc522.c
+++ b/rc522.c
@@ -409,21 +409,23 @@ static uint8_t* rc522_request(rc522_handle_t rc522, uint8_t* res_n)
     return result;
 }
 
-// TODO: return esp_err_t
-static uint8_t* rc522_anticoll(rc522_handle_t rc522)
+static esp_err_t rc522_anticoll(rc522_handle_t rc522, uint8_t** result)
 {
+    uint8_t* _result = NULL;
     uint8_t res_n;
 
-    rc522_write(rc522, 0x0D, 0x00);
-    uint8_t* result = rc522_card_write(rc522, 0x0C, (uint8_t[]) { 0x93, 0x20 }, 2, &res_n);
+    rc522_write(rc522, 0x0D, 0x00); // TODO: check return
+    _result = rc522_card_write(rc522, 0x0C, (uint8_t[]) { 0x93, 0x20 }, 2, &res_n);
 
-    if(result && res_n != 5) { // all cards/tags serial numbers is 5 bytes long (?)
-        free(result);
+    if(_result && res_n != 5) { // all cards/tags serial numbers is 5 bytes long (?)
+        free(_result);
 
-        return NULL;
+        return ESP_ERR_INVALID_RESPONSE; // TODO: return custom error
     }
 
-    return result;
+    *result = _result;
+
+    return ESP_OK;
 }
 
 static esp_err_t rc522_get_tag(rc522_handle_t rc522, uint8_t** result)
@@ -437,7 +439,7 @@ static esp_err_t rc522_get_tag(rc522_handle_t rc522, uint8_t** result)
     if(res_data != NULL) {
         free(res_data);
 
-        _result = rc522_anticoll(rc522);
+        rc522_anticoll(rc522, &_result); // TODO: Check return
 
         if(_result != NULL) {
             uint8_t buf[] = { 0x50, 0x00, 0x00, 0x00 };

--- a/rc522.c
+++ b/rc522.c
@@ -133,22 +133,23 @@ static esp_err_t rc522_antenna_on(rc522_handle_t rc522)
     return rc522_write(rc522, 0x26, 0x60); // 43dB gain
 }
 
-// TODO: return esp_err_t (and make it static?)
-rc522_config_t* rc522_clone_config(rc522_config_t* config)
+static esp_err_t rc522_clone_config(rc522_config_t* config, rc522_config_t** result)
 {
-    rc522_config_t* new_config = calloc(1, sizeof(rc522_config_t)); // TODO: memcheck
+    rc522_config_t* _clone_config = calloc(1, sizeof(rc522_config_t)); // TODO: memcheck
     
-    memcpy(new_config, config, sizeof(rc522_config_t));
+    memcpy(_clone_config, config, sizeof(rc522_config_t));
 
     // defaults
-    new_config->scan_interval_ms = config->scan_interval_ms < 50 ? RC522_DEFAULT_SCAN_INTERVAL_MS : config->scan_interval_ms;
-    new_config->task_stack_size = config->task_stack_size == 0 ? RC522_DEFAULT_TASK_STACK_SIZE : config->task_stack_size;
-    new_config->task_priority = config->task_priority == 0 ? RC522_DEFAULT_TASK_STACK_PRIORITY : config->task_priority;
-    new_config->spi.clock_speed_hz = config->spi.clock_speed_hz == 0 ? RC522_DEFAULT_SPI_CLOCK_SPEED_HZ : config->spi.clock_speed_hz;
-    new_config->i2c.rw_timeout_ms = config->i2c.rw_timeout_ms == 0 ? RC522_DEFAULT_I2C_RW_TIMEOUT_MS : config->i2c.rw_timeout_ms;
-    new_config->i2c.clock_speed_hz = config->i2c.clock_speed_hz == 0 ? RC522_DEFAULT_I2C_CLOCK_SPEED_HZ : config->i2c.clock_speed_hz;
+    _clone_config->scan_interval_ms = config->scan_interval_ms < 50 ? RC522_DEFAULT_SCAN_INTERVAL_MS : config->scan_interval_ms;
+    _clone_config->task_stack_size = config->task_stack_size == 0 ? RC522_DEFAULT_TASK_STACK_SIZE : config->task_stack_size;
+    _clone_config->task_priority = config->task_priority == 0 ? RC522_DEFAULT_TASK_STACK_PRIORITY : config->task_priority;
+    _clone_config->spi.clock_speed_hz = config->spi.clock_speed_hz == 0 ? RC522_DEFAULT_SPI_CLOCK_SPEED_HZ : config->spi.clock_speed_hz;
+    _clone_config->i2c.rw_timeout_ms = config->i2c.rw_timeout_ms == 0 ? RC522_DEFAULT_I2C_RW_TIMEOUT_MS : config->i2c.rw_timeout_ms;
+    _clone_config->i2c.clock_speed_hz = config->i2c.clock_speed_hz == 0 ? RC522_DEFAULT_I2C_CLOCK_SPEED_HZ : config->i2c.clock_speed_hz;
 
-    return new_config;
+    *result = _clone_config;
+
+    return ESP_OK;
 }
 
 static esp_err_t rc522_create_transport(rc522_handle_t rc522)
@@ -219,7 +220,7 @@ esp_err_t rc522_create(rc522_config_t* config, rc522_handle_t* out_rc522)
     esp_err_t ret;
     rc522_handle_t rc522 = calloc(1, sizeof(struct rc522)); // TODO: memcheck
 
-    rc522->config = rc522_clone_config(config);
+    rc522_clone_config(config, &(rc522->config)); // TODO: check return
 
     if(ESP_OK != (ret = rc522_create_transport(rc522))) {
         ESP_LOGE(TAG, "Cannot create transport");

--- a/rc522.h
+++ b/rc522.h
@@ -112,7 +112,7 @@ esp_err_t rc522_pause(rc522_handle_t rc522);
  * @brief Destroy RC522 and free all resources. Cannot be called from event handler.
  * @param rc522 Handle
  */
-void rc522_destroy(rc522_handle_t rc522);
+esp_err_t rc522_destroy(rc522_handle_t rc522);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Returning error codes from all functions to be able to improve memory handling.