### PR TITLE
SPI driver sends without need for second buffer

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.1.0"
+version: "3.1.2"
 description: "Library for communication with RFID / NFC cards using MFRC522 module"
 url: "https://github.com/abobija/esp-idf-rc522"
 repository: "https://github.com/abobija/esp-idf-rc522.git"

--- a/include/driver/rc522_spi.h
+++ b/include/driver/rc522_spi.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#define RC522_SPI_WRITE (0)
+#define RC522_SPI_READ  (1)
+
 typedef struct
 {
     spi_host_device_t host_id;


### PR DESCRIPTION
Optimize SPI sends by defining cmd/address phases and avoid the use of a second buffer for storing address byte