### PR TITLE
Introduced `rc522_bytes_t` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ idf.py build && ./build/test.elf
 | [ISO/IEC 14443-3](http://www.emutag.com/iso/14443-3.pdf) | Initialization and anticollision |
 | [ISO/IEC 14443-4](http://www.emutag.com/iso/14443-4.pdf) | Transmission protocol |
 | [MFRC522](https://www.nxp.com/docs/en/data-sheet/MFRC522.pdf) | MFRC522 - Standard performance MIFARE and NTAG frontend |
+| [AN10833](https://www.nxp.com/docs/en/application-note/AN10833.pdf) | MIFARE type identification procedure |
+| [AN10834](https://www.nxp.com/docs/en/application-note/AN10834.pdf) | MIFARE ISO/IEC 14443 PICC selection |
 | [MF1S50YYX_V1](https://www.nxp.com/docs/en/data-sheet/MF1S50YYX_V1.pdf) | MIFARE Classic EV1 1K |
 | [MF1S70YYX_V1](https://www.nxp.com/docs/en/data-sheet/MF1S70YYX_V1.pdf) | MIFARE Classic EV1 4K |
-
 
 ## License
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.1.2"
+version: "3.1.3"
 description: "Library for communication with RFID / NFC cards using MFRC522 module"
 url: "https://github.com/abobija/esp-idf-rc522"
 repository: "https://github.com/abobija/esp-idf-rc522.git"

--- a/private_include/rc522_driver_private.h
+++ b/private_include/rc522_driver_private.h
@@ -7,7 +7,8 @@
 
 typedef esp_err_t (*rc522_driver_install_handler_t)(rc522_driver_handle_t driver);
 
-typedef esp_err_t (*rc522_driver_send_handler_t)(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
+typedef esp_err_t (*rc522_driver_send_handler_t)(
+    rc522_driver_handle_t driver, uint8_t address, const rc522_bytes_t *bytes);
 
 typedef esp_err_t (*rc522_driver_receive_handler_t)(
     rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
@@ -31,7 +32,7 @@ esp_err_t rc522_driver_init_rst_pin(gpio_num_t rst_io_num);
 
 esp_err_t rc522_driver_create(void *config, size_t config_size, rc522_driver_handle_t *driver);
 
-esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
+esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, const rc522_bytes_t *bytes);
 
 esp_err_t rc522_driver_receive(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
 

--- a/private_include/rc522_driver_private.h
+++ b/private_include/rc522_driver_private.h
@@ -1,4 +1,5 @@
 #include <driver/gpio.h>
+#include "rc522_types_private.h"
 #include "rc522_driver.h"
 
 #define RC522_DRIVER_HARD_RST_PIN_PWR_DOWN_LEVEL (0)
@@ -6,11 +7,10 @@
 
 typedef esp_err_t (*rc522_driver_install_handler_t)(rc522_driver_handle_t driver);
 
-typedef esp_err_t (*rc522_driver_send_handler_t)(
-    rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length);
+typedef esp_err_t (*rc522_driver_send_handler_t)(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
 
 typedef esp_err_t (*rc522_driver_receive_handler_t)(
-    rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length);
+    rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
 
 typedef esp_err_t (*rc522_driver_reset_handler_t)(rc522_driver_handle_t driver);
 
@@ -31,9 +31,9 @@ esp_err_t rc522_driver_init_rst_pin(gpio_num_t rst_io_num);
 
 esp_err_t rc522_driver_create(void *config, size_t config_size, rc522_driver_handle_t *driver);
 
-esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length);
+esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
 
-esp_err_t rc522_driver_receive(rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length);
+esp_err_t rc522_driver_receive(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes);
 
 esp_err_t rc522_driver_reset(rc522_driver_handle_t driver);
 

--- a/private_include/rc522_helpers_private.h
+++ b/private_include/rc522_helpers_private.h
@@ -11,7 +11,8 @@ uint32_t rc522_millis();
 
 void rc522_delay_ms(uint32_t ms);
 
-esp_err_t rc522_buffer_to_hex_str(uint8_t *buffer, uint8_t buffer_length, char *str_buffer, uint8_t str_buffer_length);
+esp_err_t rc522_buffer_to_hex_str(
+    const uint8_t *buffer, uint8_t buffer_length, char *str_buffer, uint8_t str_buffer_length);
 
 #ifdef __cplusplus
 }

--- a/private_include/rc522_pcd_private.h
+++ b/private_include/rc522_pcd_private.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rc522_types_private.h"
 #include "rc522_pcd.h"
 
 #ifdef __cplusplus
@@ -443,11 +444,11 @@ esp_err_t rc522_pcd_stop_crypto1(rc522_handle_t rc522);
 
 esp_err_t rc522_pcd_rw_test(rc522_handle_t rc522);
 
-esp_err_t rc522_pcd_write_n(rc522_handle_t rc522, rc522_pcd_register_t addr, uint8_t n, uint8_t *data);
+esp_err_t rc522_pcd_write_n(rc522_handle_t rc522, rc522_pcd_register_t addr, rc522_bytes_t *bytes);
 
 esp_err_t rc522_pcd_write(rc522_handle_t rc522, rc522_pcd_register_t addr, uint8_t val);
 
-esp_err_t rc522_pcd_read_n(rc522_handle_t rc522, rc522_pcd_register_t addr, uint8_t n, uint8_t *buffer);
+esp_err_t rc522_pcd_read_n(rc522_handle_t rc522, rc522_pcd_register_t addr, rc522_bytes_t *bytes);
 
 esp_err_t rc522_pcd_read(rc522_handle_t rc522, rc522_pcd_register_t addr, uint8_t *value_ref);
 

--- a/private_include/rc522_pcd_private.h
+++ b/private_include/rc522_pcd_private.h
@@ -430,9 +430,9 @@ esp_err_t rc522_pcd_stop_active_command(rc522_handle_t rc522);
 
 esp_err_t rc522_pcd_clear_all_com_interrupts(rc522_handle_t rc522);
 
-esp_err_t rc522_pcd_fifo_write(rc522_handle_t rc522, uint8_t *data, uint8_t data_length);
+esp_err_t rc522_pcd_fifo_write(rc522_handle_t rc522, const rc522_bytes_t *bytes);
 
-esp_err_t rc522_pcd_fifo_read(rc522_handle_t rc522, uint8_t *buffer, uint8_t length);
+esp_err_t rc522_pcd_fifo_read(rc522_handle_t rc522, rc522_bytes_t *bytes);
 
 esp_err_t rc522_pcd_fifo_flush(rc522_handle_t rc522);
 

--- a/private_include/rc522_pcd_private.h
+++ b/private_include/rc522_pcd_private.h
@@ -419,9 +419,6 @@ esp_err_t rc522_pcd_calculate_crc(rc522_handle_t rc522, uint8_t *data, uint8_t n
 
 esp_err_t rc522_pcd_init(rc522_handle_t rc522);
 
-esp_err_t rc522_pcd_wait_for_any_bit(rc522_handle_t rc522, rc522_pcd_register_t addr, uint8_t bits, uint8_t stop_bits,
-    uint32_t timeout_ms, uint8_t *ret_state);
-
 esp_err_t rc522_pcd_firmware(rc522_handle_t rc522, rc522_pcd_firmware_t *result);
 
 char *rc522_pcd_firmware_name(rc522_pcd_firmware_t firmware);

--- a/private_include/rc522_pcd_private.h
+++ b/private_include/rc522_pcd_private.h
@@ -444,7 +444,7 @@ esp_err_t rc522_pcd_stop_crypto1(rc522_handle_t rc522);
 
 esp_err_t rc522_pcd_rw_test(rc522_handle_t rc522);
 
-esp_err_t rc522_pcd_write_n(rc522_handle_t rc522, rc522_pcd_register_t addr, rc522_bytes_t *bytes);
+esp_err_t rc522_pcd_write_n(rc522_handle_t rc522, rc522_pcd_register_t addr, const rc522_bytes_t *bytes);
 
 esp_err_t rc522_pcd_write(rc522_handle_t rc522, rc522_pcd_register_t addr, uint8_t val);
 

--- a/private_include/rc522_pcd_private.h
+++ b/private_include/rc522_pcd_private.h
@@ -415,7 +415,7 @@ typedef enum
 
 esp_err_t rc522_pcd_reset(rc522_handle_t rc522, uint32_t timeout_ms);
 
-esp_err_t rc522_pcd_calculate_crc(rc522_handle_t rc522, uint8_t *data, uint8_t n, uint8_t *buffer);
+esp_err_t rc522_pcd_calculate_crc(rc522_handle_t rc522, const rc522_bytes_t *bytes, uint16_t *result);
 
 esp_err_t rc522_pcd_init(rc522_handle_t rc522);
 

--- a/private_include/rc522_picc_private.h
+++ b/private_include/rc522_picc_private.h
@@ -75,7 +75,7 @@ esp_err_t rc522_picc_halta(rc522_handle_t rc522, rc522_picc_t *picc);
 
 esp_err_t rc522_picc_heartbeat(rc522_handle_t rc522, rc522_picc_t *picc, rc522_picc_uid_t *out_uid, uint8_t *out_sak);
 
-rc522_picc_type_t rc522_picc_type(uint8_t sak);
+rc522_picc_type_t rc522_picc_get_type_by_sak(uint8_t sak);
 
 esp_err_t rc522_picc_set_state(rc522_handle_t rc522, rc522_picc_t *picc, rc522_picc_state_t new_state, bool fire_event);
 

--- a/private_include/rc522_picc_private.h
+++ b/private_include/rc522_picc_private.h
@@ -75,7 +75,7 @@ esp_err_t rc522_picc_halta(rc522_handle_t rc522, rc522_picc_t *picc);
 
 esp_err_t rc522_picc_heartbeat(rc522_handle_t rc522, rc522_picc_t *picc, rc522_picc_uid_t *out_uid, uint8_t *out_sak);
 
-rc522_picc_type_t rc522_picc_get_type_by_sak(uint8_t sak);
+rc522_picc_type_t rc522_picc_get_type(const rc522_picc_t *picc);
 
 esp_err_t rc522_picc_set_state(rc522_handle_t rc522, rc522_picc_t *picc, rc522_picc_state_t new_state, bool fire_event);
 

--- a/private_include/rc522_types_private.h
+++ b/private_include/rc522_types_private.h
@@ -42,6 +42,12 @@ struct rc522
     EventGroupHandle_t bits;
 };
 
+typedef struct
+{
+    uint8_t *ptr;
+    uint8_t length;
+} rc522_bytes_t;
+
 #define RC522_LOG_DEFINE_BASE() static const char *TAG = RC522_LOG_TAG
 
 #define RC522_LOG(esp_log_foo, format, ...) esp_log_foo(TAG, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
@@ -66,6 +72,7 @@ struct rc522
 #define RC522_CHECK_WITH_MESSAGE(a, message) ESP_RETURN_ON_FALSE(!(a), ESP_ERR_INVALID_ARG, TAG, message)
 #define RC522_CHECK_AND_RETURN(a, ret_val)   ESP_RETURN_ON_FALSE(!(a), ret_val, TAG, #a)
 #define RC522_CHECK(a)                       ESP_RETURN_ON_FALSE(!(a), ESP_ERR_INVALID_ARG, TAG, #a)
+#define RC522_CHECK_BYTES(b)                 RC522_CHECK(b == NULL || (b)->ptr == NULL || (b)->length < 1)
 
 #define RC522_RETURN_ON_ERROR_SILENTLY(x)                                                                              \
     do {                                                                                                               \

--- a/src/driver/rc522_i2c.c
+++ b/src/driver/rc522_i2c.c
@@ -26,7 +26,7 @@ static esp_err_t rc522_i2c_install(rc522_driver_handle_t driver)
     return ESP_OK;
 }
 
-static esp_err_t rc522_i2c_send(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes)
+static esp_err_t rc522_i2c_send(rc522_driver_handle_t driver, uint8_t address, const rc522_bytes_t *bytes)
 {
     RC522_CHECK(driver == NULL);
     RC522_CHECK(driver->config == NULL);

--- a/src/driver/rc522_i2c.c
+++ b/src/driver/rc522_i2c.c
@@ -9,6 +9,7 @@ RC522_LOG_DEFINE_BASE();
 static esp_err_t rc522_i2c_install(rc522_driver_handle_t driver)
 {
     RC522_CHECK(driver == NULL);
+    RC522_CHECK(driver->config == NULL);
 
     rc522_i2c_config_t *conf = (rc522_i2c_config_t *)(driver->config);
 
@@ -25,36 +26,44 @@ static esp_err_t rc522_i2c_install(rc522_driver_handle_t driver)
     return ESP_OK;
 }
 
-static esp_err_t rc522_i2c_send(rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length)
+static esp_err_t rc522_i2c_send(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes)
 {
+    RC522_CHECK(driver == NULL);
+    RC522_CHECK(driver->config == NULL);
+    RC522_CHECK_BYTES(bytes);
+
     // FIXME: Find a way to send [address + buffer]
     //        without need for second buffer
     uint8_t buffer2[64];
 
     buffer2[0] = address;
-    memcpy(buffer2 + 1, buffer, length);
+    memcpy(buffer2 + 1, bytes->ptr, bytes->length);
 
     rc522_i2c_config_t *conf = (rc522_i2c_config_t *)(driver->config);
 
     RC522_RETURN_ON_ERROR(i2c_master_write_to_device(conf->port,
         conf->device_address,
         buffer2,
-        (length + 1),
+        (bytes->length + 1),
         pdMS_TO_TICKS(conf->rw_timeout_ms)));
 
     return ESP_OK;
 }
 
-static esp_err_t rc522_i2c_receive(rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length)
+static esp_err_t rc522_i2c_receive(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes)
 {
+    RC522_CHECK(driver == NULL);
+    RC522_CHECK(driver->config == NULL);
+    RC522_CHECK_BYTES(bytes);
+
     rc522_i2c_config_t *conf = (rc522_i2c_config_t *)(driver->config);
 
     RC522_RETURN_ON_ERROR(i2c_master_write_read_device(conf->port,
         conf->device_address,
         &address,
         1,
-        buffer,
-        length,
+        bytes->ptr,
+        bytes->length,
         pdMS_TO_TICKS(conf->rw_timeout_ms)));
 
     return ESP_OK;
@@ -62,6 +71,9 @@ static esp_err_t rc522_i2c_receive(rc522_driver_handle_t driver, uint8_t address
 
 static esp_err_t rc522_i2c_reset(rc522_driver_handle_t driver)
 {
+    RC522_CHECK(driver == NULL);
+    RC522_CHECK(driver->config == NULL);
+
     rc522_i2c_config_t *conf = (rc522_i2c_config_t *)(driver->config);
 
     if (conf->rst_io_num < 0) {
@@ -79,6 +91,7 @@ static esp_err_t rc522_i2c_reset(rc522_driver_handle_t driver)
 static esp_err_t rc522_i2c_uninstall(rc522_driver_handle_t driver)
 {
     RC522_CHECK(driver == NULL);
+    RC522_CHECK(driver->config == NULL);
 
     rc522_i2c_config_t *conf = (rc522_i2c_config_t *)(driver->config);
 

--- a/src/driver/rc522_spi.c
+++ b/src/driver/rc522_spi.c
@@ -54,7 +54,7 @@ static esp_err_t rc522_spi_install(rc522_driver_handle_t driver)
     return ESP_OK;
 }
 
-static esp_err_t rc522_spi_send(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes)
+static esp_err_t rc522_spi_send(rc522_driver_handle_t driver, uint8_t address, const rc522_bytes_t *bytes)
 {
     RC522_CHECK(driver == NULL);
     RC522_CHECK(driver->device == NULL);

--- a/src/rc522.c
+++ b/src/rc522.c
@@ -270,7 +270,7 @@ void rc522_task(void *arg)
 
             memcpy(&rc522->picc.uid, &uid, sizeof(rc522_picc_uid_t));
             rc522->picc.sak = sak;
-            rc522->picc.type = rc522_picc_get_type_by_sak(sak);
+            rc522->picc.type = rc522_picc_get_type(&rc522->picc);
 
             if (rc522->picc.state == RC522_PICC_STATE_READY) {
                 rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_ACTIVE, true);

--- a/src/rc522.c
+++ b/src/rc522.c
@@ -270,7 +270,7 @@ void rc522_task(void *arg)
 
             memcpy(&rc522->picc.uid, &uid, sizeof(rc522_picc_uid_t));
             rc522->picc.sak = sak;
-            rc522->picc.type = rc522_picc_type(sak);
+            rc522->picc.type = rc522_picc_get_type_by_sak(sak);
 
             if (rc522->picc.state == RC522_PICC_STATE_READY) {
                 rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_ACTIVE, true);

--- a/src/rc522_driver.c
+++ b/src/rc522_driver.c
@@ -30,22 +30,20 @@ inline esp_err_t rc522_driver_install(rc522_driver_handle_t driver)
     return driver->install(driver);
 }
 
-inline esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length)
+inline esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes)
 {
     RC522_CHECK(driver == NULL);
-    RC522_CHECK(buffer == NULL);
-    RC522_CHECK(length < 1);
+    RC522_CHECK_BYTES(bytes);
 
-    return driver->send(driver, address, buffer, length);
+    return driver->send(driver, address, bytes);
 }
 
-inline esp_err_t rc522_driver_receive(rc522_driver_handle_t driver, uint8_t address, uint8_t *buffer, uint8_t length)
+inline esp_err_t rc522_driver_receive(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes)
 {
     RC522_CHECK(driver == NULL);
-    RC522_CHECK(buffer == NULL);
-    RC522_CHECK(length < 1);
+    RC522_CHECK_BYTES(bytes);
 
-    return driver->receive(driver, address, buffer, length);
+    return driver->receive(driver, address, bytes);
 }
 
 inline esp_err_t rc522_driver_reset(rc522_driver_handle_t driver)

--- a/src/rc522_driver.c
+++ b/src/rc522_driver.c
@@ -30,7 +30,7 @@ inline esp_err_t rc522_driver_install(rc522_driver_handle_t driver)
     return driver->install(driver);
 }
 
-inline esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, rc522_bytes_t *bytes)
+inline esp_err_t rc522_driver_send(rc522_driver_handle_t driver, uint8_t address, const rc522_bytes_t *bytes)
 {
     RC522_CHECK(driver == NULL);
     RC522_CHECK_BYTES(bytes);

--- a/src/rc522_helpers.c
+++ b/src/rc522_helpers.c
@@ -24,7 +24,8 @@ void rc522_delay_ms(uint32_t ms)
     vTaskDelay(pdMS_TO_TICKS(ms));
 }
 
-esp_err_t rc522_buffer_to_hex_str(uint8_t *buffer, uint8_t buffer_length, char *str_buffer, uint8_t str_buffer_length)
+esp_err_t rc522_buffer_to_hex_str(
+    const uint8_t *buffer, uint8_t buffer_length, char *str_buffer, uint8_t str_buffer_length)
 {
     RC522_CHECK(buffer == NULL);
     RC522_CHECK(buffer_length < 1);

--- a/src/rc522_pcd.c
+++ b/src/rc522_pcd.c
@@ -324,7 +324,7 @@ esp_err_t rc522_pcd_rw_test(rc522_handle_t rc522)
     return ESP_OK;
 }
 
-inline esp_err_t rc522_pcd_write_n(rc522_handle_t rc522, rc522_pcd_register_t addr, rc522_bytes_t *bytes)
+inline esp_err_t rc522_pcd_write_n(rc522_handle_t rc522, rc522_pcd_register_t addr, const rc522_bytes_t *bytes)
 {
     if (RC522_LOG_LEVEL >= ESP_LOG_VERBOSE) {
         char debug_buffer[64];

--- a/src/rc522_pcd.c
+++ b/src/rc522_pcd.c
@@ -323,6 +323,9 @@ esp_err_t rc522_pcd_rw_test(rc522_handle_t rc522)
 
 inline esp_err_t rc522_pcd_write_n(rc522_handle_t rc522, rc522_pcd_register_t addr, const rc522_bytes_t *bytes)
 {
+    RC522_CHECK(rc522 == NULL);
+    RC522_CHECK_BYTES(bytes);
+
     if (RC522_LOG_LEVEL >= ESP_LOG_VERBOSE) {
         char debug_buffer[64];
         rc522_buffer_to_hex_str(bytes->ptr, bytes->length, debug_buffer, sizeof(debug_buffer));
@@ -341,6 +344,9 @@ inline esp_err_t rc522_pcd_write(rc522_handle_t rc522, rc522_pcd_register_t addr
 
 inline esp_err_t rc522_pcd_read_n(rc522_handle_t rc522, rc522_pcd_register_t addr, rc522_bytes_t *bytes)
 {
+    RC522_CHECK(rc522 == NULL);
+    RC522_CHECK_BYTES(bytes);
+
     esp_err_t ret = rc522_driver_receive(rc522->config->driver, addr, bytes);
 
     if (RC522_LOG_LEVEL >= ESP_LOG_VERBOSE) {

--- a/src/rc522_picc.c
+++ b/src/rc522_picc.c
@@ -39,7 +39,7 @@ esp_err_t rc522_picc_comm(rc522_handle_t rc522, rc522_pcd_command_t command, uin
     RC522_RETURN_ON_ERROR(rc522_pcd_stop_active_command(rc522));
     RC522_RETURN_ON_ERROR(rc522_pcd_clear_all_com_interrupts(rc522));
     RC522_RETURN_ON_ERROR(rc522_pcd_fifo_flush(rc522));
-    RC522_RETURN_ON_ERROR(rc522_pcd_fifo_write(rc522, send_data, send_data_len));
+    RC522_RETURN_ON_ERROR(rc522_pcd_fifo_write(rc522, &(rc522_bytes_t) { .ptr = send_data, .length = send_data_len }));
     RC522_RETURN_ON_ERROR(rc522_pcd_write(rc522, RC522_PCD_BIT_FRAMING_REG, bit_framing)); // Bit adjustments
     RC522_RETURN_ON_ERROR(rc522_pcd_write(rc522, RC522_PCD_COMMAND_REG, command));         // Execute the command
 
@@ -122,7 +122,7 @@ esp_err_t rc522_picc_comm(rc522_handle_t rc522, rc522_pcd_command_t command, uin
         *back_data_len = fifo_level; // Number of bytes returned
 
         uint8_t b0_orig = back_data[0];
-        RC522_RETURN_ON_ERROR(rc522_pcd_fifo_read(rc522, back_data, fifo_level));
+        RC522_RETURN_ON_ERROR(rc522_pcd_fifo_read(rc522, &(rc522_bytes_t) { .ptr = back_data, .length = fifo_level }));
 
         if (RC522_LOG_LEVEL >= ESP_LOG_DEBUG) {
             char debug_buffer[64];

--- a/src/rc522_picc.c
+++ b/src/rc522_picc.c
@@ -651,65 +651,6 @@ esp_err_t rc522_picc_heartbeat(rc522_handle_t rc522, rc522_picc_t *picc, rc522_p
     return ESP_OK;
 }
 
-rc522_picc_type_t rc522_picc_type(uint8_t sak)
-{
-    // http://www.nxp.com/documents/application_note/AN10833.pdf
-    // 3.2 Coding of Select Acknowledge (SAK)
-    // ignore 8-bit (iso14443 starts with LSBit = bit 1)
-    // fixes wrong type for manufacturer Infineon (http://nfc-tools.org/index.php?title=ISO14443A)
-    sak &= 0x7F;
-
-    switch (sak) {
-        case 0x09:
-            return RC522_PICC_TYPE_MIFARE_MINI;
-        case 0x08:
-            return RC522_PICC_TYPE_MIFARE_1K;
-        case 0x18:
-            return RC522_PICC_TYPE_MIFARE_4K;
-        case 0x00:
-            return RC522_PICC_TYPE_MIFARE_UL;
-        case 0x10:
-        case 0x11:
-            return RC522_PICC_TYPE_MIFARE_PLUS;
-        case 0x01:
-            return RC522_PICC_TYPE_TNP3XXX;
-        case 0x20:
-            return RC522_PICC_TYPE_ISO_14443_4;
-        case 0x40:
-            return RC522_PICC_TYPE_ISO_18092;
-        default:
-            return RC522_PICC_TYPE_UNKNOWN;
-    }
-}
-
-char *rc522_picc_type_name(rc522_picc_type_t type)
-{
-    switch (type) {
-        case RC522_PICC_TYPE_ISO_14443_4:
-            return "PICC compliant with ISO/IEC 14443-4";
-        case RC522_PICC_TYPE_ISO_18092:
-            return "PICC compliant with ISO/IEC 18092 (NFC)";
-        case RC522_PICC_TYPE_MIFARE_MINI:
-            return "MIFARE Mini, 320 bytes";
-        case RC522_PICC_TYPE_MIFARE_1K:
-            return "MIFARE 1K";
-        case RC522_PICC_TYPE_MIFARE_4K:
-            return "MIFARE 4K";
-        case RC522_PICC_TYPE_MIFARE_UL:
-            return "MIFARE Ultralight or Ultralight C";
-        case RC522_PICC_TYPE_MIFARE_PLUS:
-            return "MIFARE Plus";
-        case RC522_PICC_TYPE_MIFARE_DESFIRE:
-            return "MIFARE DESFire";
-        case RC522_PICC_TYPE_TNP3XXX:
-            return "MIFARE TNP3XXX";
-        case RC522_PICC_TYPE_UNDEFINED:
-        case RC522_PICC_TYPE_UNKNOWN:
-        default:
-            return "unknown";
-    }
-}
-
 esp_err_t rc522_picc_uid_to_str(rc522_picc_uid_t *uid, char *buffer, uint8_t buffer_size)
 {
     RC522_CHECK(uid == NULL);
@@ -787,6 +728,65 @@ esp_err_t rc522_picc_set_state(rc522_handle_t rc522, rc522_picc_t *picc, rc522_p
     }
 
     return ret;
+}
+
+rc522_picc_type_t rc522_picc_get_type_by_sak(uint8_t sak)
+{
+    // http://www.nxp.com/documents/application_note/AN10833.pdf
+    // 3.2 Coding of Select Acknowledge (SAK)
+    // ignore 8-bit (iso14443 starts with LSBit = bit 1)
+    // fixes wrong type for manufacturer Infineon (http://nfc-tools.org/index.php?title=ISO14443A)
+    sak &= 0x7F;
+
+    switch (sak) {
+        case 0x09:
+            return RC522_PICC_TYPE_MIFARE_MINI;
+        case 0x08:
+            return RC522_PICC_TYPE_MIFARE_1K;
+        case 0x18:
+            return RC522_PICC_TYPE_MIFARE_4K;
+        case 0x00:
+            return RC522_PICC_TYPE_MIFARE_UL;
+        case 0x10:
+        case 0x11:
+            return RC522_PICC_TYPE_MIFARE_PLUS;
+        case 0x01:
+            return RC522_PICC_TYPE_TNP3XXX;
+        case 0x20:
+            return RC522_PICC_TYPE_ISO_14443_4;
+        case 0x40:
+            return RC522_PICC_TYPE_ISO_18092;
+        default:
+            return RC522_PICC_TYPE_UNKNOWN;
+    }
+}
+
+char *rc522_picc_type_name(rc522_picc_type_t type)
+{
+    switch (type) {
+        case RC522_PICC_TYPE_ISO_14443_4:
+            return "PICC compliant with ISO/IEC 14443-4";
+        case RC522_PICC_TYPE_ISO_18092:
+            return "PICC compliant with ISO/IEC 18092 (NFC)";
+        case RC522_PICC_TYPE_MIFARE_MINI:
+            return "MIFARE Mini, 320 bytes";
+        case RC522_PICC_TYPE_MIFARE_1K:
+            return "MIFARE 1K";
+        case RC522_PICC_TYPE_MIFARE_4K:
+            return "MIFARE 4K";
+        case RC522_PICC_TYPE_MIFARE_UL:
+            return "MIFARE Ultralight or Ultralight C";
+        case RC522_PICC_TYPE_MIFARE_PLUS:
+            return "MIFARE Plus";
+        case RC522_PICC_TYPE_MIFARE_DESFIRE:
+            return "MIFARE DESFire";
+        case RC522_PICC_TYPE_TNP3XXX:
+            return "MIFARE TNP3XXX";
+        case RC522_PICC_TYPE_UNDEFINED:
+        case RC522_PICC_TYPE_UNKNOWN:
+        default:
+            return "unknown";
+    }
 }
 
 esp_err_t rc522_picc_print(rc522_picc_t *picc)

--- a/src/rc522_picc.c
+++ b/src/rc522_picc.c
@@ -730,11 +730,16 @@ esp_err_t rc522_picc_set_state(rc522_handle_t rc522, rc522_picc_t *picc, rc522_p
     return ret;
 }
 
-rc522_picc_type_t rc522_picc_get_type_by_sak(uint8_t sak)
+rc522_picc_type_t rc522_picc_get_type(const rc522_picc_t *picc)
 {
+    RC522_CHECK(picc == NULL);
+
+    uint8_t sak = picc->sak;
+
     // http://www.nxp.com/documents/application_note/AN10833.pdf
-    // 3.2 Coding of Select Acknowledge (SAK)
-    // ignore 8-bit (iso14443 starts with LSBit = bit 1)
+    // Section: Coding of Select Acknowledge (SAK)
+
+    // ignore 8th (iso14443 starts with LSBit = bit 1)
     // fixes wrong type for manufacturer Infineon (http://nfc-tools.org/index.php?title=ISO14443A)
     sak &= 0x7F;
 
@@ -753,7 +758,7 @@ rc522_picc_type_t rc522_picc_get_type_by_sak(uint8_t sak)
         case 0x01:
             return RC522_PICC_TYPE_TNP3XXX;
         case 0x20:
-            return RC522_PICC_TYPE_ISO_14443_4;
+            return picc->atqa.source == 0x4400 ? RC522_PICC_TYPE_MIFARE_DESFIRE : RC522_PICC_TYPE_ISO_14443_4;
         case 0x40:
             return RC522_PICC_TYPE_ISO_18092;
         default:


### PR DESCRIPTION
- Introduced `rc522_bytes_t` type that wraps pointer to byte array and it's length
- Function for CRC calculation now uses uint16_t as the result pointer
- Added missing condition for returning MIFARE Desfire picc type