### PR TITLE
Remove block's buffer_size arg from mifare read/write functions

### DIFF
--- a/examples/multiple_scanners/main/multiple_scanners.c
+++ b/examples/multiple_scanners/main/multiple_scanners.c
@@ -16,7 +16,7 @@ static const char *TAG = "rc522-multiple-scanners-example";
 #define RC522_SPI_SCANNER_1_GPIO_SDA (22)
 #define RC522_SPI_SCANNER_2_GPIO_SDA (26)
 
-// {{ Reader configurations
+// {{ Scanner configurations
 
 static rc522_spi_config_t scanner_1_config = {
     .host_id = VSPI_HOST,
@@ -49,7 +49,7 @@ static rc522_spi_config_t scanner_2_config = {
 static rc522_driver_handle_t driver_1;
 static rc522_driver_handle_t driver_2;
 
-// Readers
+// Scanners
 
 static rc522_handle_t scanner_1;
 static rc522_handle_t scanner_2;

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.1.6"
+version: "3.2.0"
 description: "Library for communication with RFID / NFC cards using MFRC522 module"
 url: "https://github.com/abobija/esp-idf-rc522"
 repository: "https://github.com/abobija/esp-idf-rc522.git"

--- a/include/picc/rc522_mifare.h
+++ b/include/picc/rc522_mifare.h
@@ -113,11 +113,10 @@ esp_err_t rc522_mifare_auth(
  * @param rc522 RC522 handle
  * @param picc PICC that is currently selected
  * @param block_address Address of the block to read
- * @param[out] out_buffer Buffer to store the retrived data in
- * @param buffer_size Size of the @c out_buffer (should be at least @c RC522_MIFARE_BLOCK_SIZE)
+ * @param[out] out_buffer Buffer of exactly @c RC522_MIFARE_BLOCK_SIZE bytes to store the retrived data in
  */
 esp_err_t rc522_mifare_read(const rc522_handle_t rc522, const rc522_picc_t *picc, uint8_t block_address,
-    uint8_t *out_buffer, uint8_t buffer_size);
+    uint8_t out_buffer[RC522_MIFARE_BLOCK_SIZE]);
 
 /**
  * @brief Write to a block at the given @c block_address on the PICC.
@@ -127,11 +126,10 @@ esp_err_t rc522_mifare_read(const rc522_handle_t rc522, const rc522_picc_t *picc
  * @param rc522 RC522 handle
  * @param picc PICC that is currently selected
  * @param block_address Address of the block to write
- * @param[in] buffer Buffer containing the data to write
- * @param buffer_size Size of the @c buffer (should be at least @c RC522_MIFARE_BLOCK_SIZE)
+ * @param[in] buffer Buffer of exactly @c RC522_MIFARE_BLOCK_SIZE that contains the data to write
  */
 esp_err_t rc522_mifare_write(const rc522_handle_t rc522, const rc522_picc_t *picc, uint8_t block_address,
-    const uint8_t *buffer, uint8_t buffer_size);
+    const uint8_t buffer[RC522_MIFARE_BLOCK_SIZE]);
 
 // }}
 

--- a/src/picc/rc522_mifare.c
+++ b/src/picc/rc522_mifare.c
@@ -135,12 +135,11 @@ esp_err_t rc522_mifare_auth(
 }
 
 esp_err_t rc522_mifare_read(const rc522_handle_t rc522, const rc522_picc_t *picc, uint8_t block_address,
-    uint8_t *out_buffer, uint8_t buffer_size)
+    uint8_t out_buffer[RC522_MIFARE_BLOCK_SIZE])
 {
     RC522_CHECK(rc522 == NULL);
     RC522_CHECK(picc == NULL);
     RC522_CHECK(out_buffer == NULL);
-    RC522_CHECK(buffer_size < RC522_MIFARE_BLOCK_SIZE);
 
     RC522_LOGD("MIFARE READ (block_address=%02" RC522_X ")", block_address);
 
@@ -334,12 +333,11 @@ static esp_err_t rc522_mifare_confirm_sector_trailer_write_permission_config(uin
 }
 
 esp_err_t rc522_mifare_write(const rc522_handle_t rc522, const rc522_picc_t *picc, uint8_t block_address,
-    const uint8_t *buffer, uint8_t buffer_size)
+    const uint8_t buffer[RC522_MIFARE_BLOCK_SIZE])
 {
     RC522_CHECK(rc522 == NULL);
     RC522_CHECK(picc == NULL);
     RC522_CHECK(buffer == NULL);
-    RC522_CHECK(buffer_size < RC522_MIFARE_BLOCK_SIZE);
     RC522_CHECK(!rc522_mifare_type_is_classic_compatible(picc->type));
     RC522_CHECK(rc522_mifare_confirm_sector_trailer_write_permission_config(block_address) != ESP_OK);
 
@@ -513,7 +511,7 @@ esp_err_t rc522_mifare_read_sector_trailer_block(const rc522_handle_t rc522, con
     block.address = (sector_desc->block_0_address + sector_desc->number_of_blocks - 1);
     block.type = RC522_MIFARE_BLOCK_TRAILER;
 
-    RC522_RETURN_ON_ERROR(rc522_mifare_read(rc522, picc, block.address, block.bytes, sizeof(block.bytes)));
+    RC522_RETURN_ON_ERROR(rc522_mifare_read(rc522, picc, block.address, block.bytes));
     block.error = rc522_mifare_parse_sector_trailer(block.bytes, sizeof(block.bytes), &block.trailer_info);
     memcpy(&block.access_bits, &block.trailer_info.access_bits[3], sizeof(rc522_mifare_access_bits_t));
 
@@ -541,7 +539,7 @@ esp_err_t rc522_mifare_read_sector_block(const rc522_handle_t rc522, const rc522
 
     block.address = (sector_desc->block_0_address + block_offset);
 
-    RC522_RETURN_ON_ERROR(rc522_mifare_read(rc522, picc, block.address, block.bytes, sizeof(block.bytes)));
+    RC522_RETURN_ON_ERROR(rc522_mifare_read(rc522, picc, block.address, block.bytes));
 
     uint8_t group = 0;
     RC522_RETURN_ON_ERROR(rc522_mifare_get_sector_block_group_index(sector_desc, block_offset, &group));


### PR DESCRIPTION
Since it's always 16 bytes