### PR TITLE
Using SPI3_HOST instead of VSPI_HOST

### DIFF
--- a/examples/basic/main/basic.c
+++ b/examples/basic/main/basic.c
@@ -12,7 +12,7 @@ static const char *TAG = "rc522-basic-example";
 #define RC522_SCANNER_GPIO_RST     (-1) // soft-reset
 
 static rc522_spi_config_t driver_config = {
-    .host_id = VSPI_HOST,
+    .host_id = SPI3_HOST,
     .bus_config = &(spi_bus_config_t){
         .miso_io_num = RC522_SPI_BUS_GPIO_MISO,
         .mosi_io_num = RC522_SPI_BUS_GPIO_MOSI,

--- a/examples/memory_dump/main/memory_dump.c
+++ b/examples/memory_dump/main/memory_dump.c
@@ -14,7 +14,7 @@ static const char *TAG = "rc522-memory-dump-example";
 #define RC522_SCANNER_GPIO_RST     (-1) // soft-reset
 
 static rc522_spi_config_t driver_config = {
-    .host_id = VSPI_HOST,
+    .host_id = SPI3_HOST,
     .bus_config = &(spi_bus_config_t){
         .miso_io_num = RC522_SPI_BUS_GPIO_MISO,
         .mosi_io_num = RC522_SPI_BUS_GPIO_MOSI,

--- a/examples/multiple_scanners/main/multiple_scanners.c
+++ b/examples/multiple_scanners/main/multiple_scanners.c
@@ -19,7 +19,7 @@ static const char *TAG = "rc522-multiple-scanners-example";
 // {{ Scanner configurations
 
 static rc522_spi_config_t scanner_1_config = {
-    .host_id = VSPI_HOST,
+    .host_id = SPI3_HOST,
     .bus_config = &(spi_bus_config_t){
         .miso_io_num = RC522_SPI_BUS_GPIO_MISO,
         .mosi_io_num = RC522_SPI_BUS_GPIO_MOSI,
@@ -35,7 +35,7 @@ static rc522_spi_config_t scanner_1_config = {
 // since first scanner will initialize the bus.
 
 static rc522_spi_config_t scanner_2_config = {
-    .host_id = VSPI_HOST,
+    .host_id = SPI3_HOST,
     .dev_config = {
         .spics_io_num = RC522_SPI_SCANNER_2_GPIO_SDA,
     },

--- a/examples/read_write/main/read_write.c
+++ b/examples/read_write/main/read_write.c
@@ -16,7 +16,7 @@ static const char *TAG = "rc522-read-write-example";
 #define RC522_SCANNER_GPIO_RST     (-1) // soft-reset
 
 static rc522_spi_config_t driver_config = {
-    .host_id = VSPI_HOST,
+    .host_id = SPI3_HOST,
     .bus_config = &(spi_bus_config_t){
         .miso_io_num = RC522_SPI_BUS_GPIO_MISO,
         .mosi_io_num = RC522_SPI_BUS_GPIO_MOSI,

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.2.3"
+version: "3.2.4"
 description: "Library for communication with RFID / NFC cards using MFRC522 module"
 url: "https://github.com/abobija/esp-idf-rc522"
 repository: "https://github.com/abobija/esp-idf-rc522.git"


### PR DESCRIPTION
For better compatibility with other ESP32s (like S3)

inspirated by #71 