### PR TITLE
CI: Validate on IDF 5.5 instead of latest

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -62,7 +62,7 @@ jobs:
           - release-v5.2
           - release-v5.3
           - release-v5.4
-          - latest
+          - release-v5.5
         idf_target:
           - esp32
 


### PR DESCRIPTION
The `latest` IDF branch has increased version to 6. Instead of `latest` branch CI will validate on latest 5 version which is 5.5