### PR TITLE
Support for more than 3 readers

### DIFF
--- a/include/driver/rc522_spi.h
+++ b/include/driver/rc522_spi.h
@@ -27,7 +27,7 @@ typedef struct
      * GPIO number of the RC522 nCS pin.
      * This is used if you have more than 3 devices on your SPI bus (typically SPI3).
      * If you wish to use this parameter, you must set `dev_config.spics_io_num`
-     * to -1. For backwards compatability, this parameter is ignored if you have set
+     * to -1. For backwards compatibility, this parameter is ignored if you have set
      * `dev_config.spics_io_num` to any other value than -1.
      */
     gpio_num_t ncs_io_num;

--- a/include/driver/rc522_spi.h
+++ b/include/driver/rc522_spi.h
@@ -23,6 +23,14 @@ typedef struct
      * Set to -1 if the RST pin is not connected.
      */
     gpio_num_t rst_io_num;
+    /**
+     * GPIO number of the RC522 nCS pin.
+     * This is used if you have more than 3 devices on your SPI bus (typically SPI3).
+     * If you wish to use this parameter, you must set `dev_config.spics_io_num`
+     * to -1. For backwards compatability, this parameter is ignored if you have set
+     * `dev_config.spics_io_num` to any other value than -1.
+     */
+    gpio_num_t ncs_io_num;
 } rc522_spi_config_t;
 
 esp_err_t rc522_spi_create(const rc522_spi_config_t *config, rc522_driver_handle_t *driver);

--- a/internal/rc522_driver_internal.h
+++ b/internal/rc522_driver_internal.h
@@ -2,6 +2,7 @@
 #include "rc522_types_internal.h"
 #include "rc522_driver.h"
 
+#define RC522_DRIVER_NCS_PIN_SELECT (0)
 #define RC522_DRIVER_HARD_RST_PIN_PWR_DOWN_LEVEL (0)
 #define RC522_DRIVER_HARD_RST_PULSE_DURATION_MS  (15)
 

--- a/internal/rc522_driver_internal.h
+++ b/internal/rc522_driver_internal.h
@@ -2,7 +2,7 @@
 #include "rc522_types_internal.h"
 #include "rc522_driver.h"
 
-#define RC522_DRIVER_NCS_PIN_SELECT (0)
+#define RC522_DRIVER_NCS_PIN_SELECT              (0)
 #define RC522_DRIVER_HARD_RST_PIN_PWR_DOWN_LEVEL (0)
 #define RC522_DRIVER_HARD_RST_PULSE_DURATION_MS  (15)
 

--- a/internal/rc522_types_internal.h
+++ b/internal/rc522_types_internal.h
@@ -68,6 +68,15 @@ typedef struct
     }                                                                                                                  \
     while (0)
 
+#define RC522_LOG_ON_ERROR(x)                                                                                          \
+    do {                                                                                                               \
+        esp_err_t err_rc_ = (x);                                                                                       \
+        if (unlikely(err_rc_ != ESP_OK)) {                                                                             \
+            ESP_LOGE(TAG, "%s(%d): %04" RC522_X "", __FUNCTION__, __LINE__, err_rc_);                                  \
+        }                                                                                                              \
+    }                                                                                                                  \
+    while (0)
+
 #define RC522_RETURN_ON_FALSE(a, err_code)   ESP_RETURN_ON_FALSE(a, err_code, TAG, "")
 #define RC522_CHECK_WITH_MESSAGE(a, message) ESP_RETURN_ON_FALSE(!(a), ESP_ERR_INVALID_ARG, TAG, message)
 #define RC522_CHECK_AND_RETURN(a, ret_val)   ESP_RETURN_ON_FALSE(!(a), ret_val, TAG, #a)

--- a/src/driver/rc522_spi.c
+++ b/src/driver/rc522_spi.c
@@ -9,7 +9,6 @@ RC522_LOG_DEFINE_BASE();
 static void rc522_spi_transaction_pre_cb(spi_transaction_t *trans);
 static void rc522_spi_transaction_post_cb(spi_transaction_t *trans);
 
-
 static esp_err_t rc522_spi_install(const rc522_driver_handle_t driver)
 {
     RC522_CHECK(driver == NULL);
@@ -77,7 +76,7 @@ static esp_err_t rc522_spi_send(const rc522_driver_handle_t driver, uint8_t addr
             .addr = address,
             .length = 8 * bytes->length,
             .tx_buffer = bytes->ptr,
-            .user = (void*) driver->config,
+            .user = (void *)driver->config,
         });
 
     return ret;
@@ -99,7 +98,7 @@ static esp_err_t rc522_spi_receive(const rc522_driver_handle_t driver, uint8_t a
                 .addr = address,
                 .rxlength = 8,
                 .rx_buffer = (bytes->ptr + i),
-                .user = (void*) driver->config,
+                .user = (void *)driver->config,
             }));
     }
 
@@ -163,12 +162,12 @@ esp_err_t rc522_spi_create(const rc522_spi_config_t *config, rc522_driver_handle
 
 static void rc522_spi_transaction_pre_cb(spi_transaction_t *trans)
 {
-    rc522_spi_config_t *conf = (rc522_spi_config_t*) trans->user;
+    rc522_spi_config_t *conf = (rc522_spi_config_t *)trans->user;
     RC522_LOG_ON_ERROR(gpio_set_level(conf->ncs_io_num, RC522_DRIVER_NCS_PIN_SELECT));
 }
 
 static void rc522_spi_transaction_post_cb(spi_transaction_t *trans)
 {
-    rc522_spi_config_t *conf = (rc522_spi_config_t*) trans->user;
+    rc522_spi_config_t *conf = (rc522_spi_config_t *)trans->user;
     RC522_LOG_ON_ERROR(gpio_set_level(conf->ncs_io_num, !RC522_DRIVER_NCS_PIN_SELECT));
 }

--- a/src/rc522_driver.c
+++ b/src/rc522_driver.c
@@ -5,6 +5,24 @@
 
 RC522_LOG_DEFINE_BASE();
 
+esp_err_t rc522_driver_init_ncs_pin(gpio_num_t rst_io_num)
+{
+    RC522_CHECK(rst_io_num < 0);
+
+    gpio_config_t io_conf = {
+        .intr_type = GPIO_INTR_DISABLE,
+        .mode = GPIO_MODE_OUTPUT,
+        .pin_bit_mask = (1ULL << rst_io_num),
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+    };
+
+    RC522_RETURN_ON_ERROR(gpio_config(&io_conf));
+    RC522_RETURN_ON_ERROR(gpio_set_level(rst_io_num, !RC522_DRIVER_NCS_PIN_SELECT));
+
+    return ESP_OK;
+}
+
 esp_err_t rc522_driver_init_rst_pin(gpio_num_t rst_io_num)
 {
     RC522_CHECK(rst_io_num < 0);


### PR DESCRIPTION
This PR adds support for more than three readers by allowing a regular driver controlled GPIO as chip select. When using eg. SPI3, the nCS signals are hardware controlled and the ESP32 only supports 3 of them on eg. SPI3.