### PR TITLE
Implement Multi-Tag Scanning Support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -11,4 +11,12 @@ menu "RC522"
             writing incorrect access bits, which could render the sector
             unusable.
 
+    config RC522_PICC_SLOT_COUNT
+        int "Number of available tag slots for RC522 devices"
+        default 2
+        range 1 8
+        help
+            This option sets the number of available tag slots for RC522 devices.
+            Each slot can hold one tag. The default value is 2.
+
 endmenu

--- a/examples/basic/main/basic.c
+++ b/examples/basic/main/basic.c
@@ -33,10 +33,12 @@ static void on_picc_state_changed(void *arg, esp_event_base_t base, int32_t even
     rc522_picc_t *picc = event->picc;
 
     if (picc->state == RC522_PICC_STATE_ACTIVE) {
+        ESP_LOGI(TAG, "Card has been detected");
         rc522_picc_print(picc);
     }
-    else if (picc->state == RC522_PICC_STATE_IDLE && event->old_state >= RC522_PICC_STATE_ACTIVE) {
+    else if (picc->state == RC522_PICC_STATE_IDLE) {
         ESP_LOGI(TAG, "Card has been removed");
+        rc522_picc_print(picc);
     }
 }
 

--- a/include/rc522_picc.h
+++ b/include/rc522_picc.h
@@ -66,6 +66,8 @@ typedef enum
      * this state to get the complete UID.
      *
      * The PICC enters the ACTIVE State when it is selected with its complete UID.
+     * 
+     * Not used though
      */
     RC522_PICC_STATE_READY,
 
@@ -99,6 +101,8 @@ typedef enum
      * Cascade levels are handled inside this state to get complete UID.
      *
      * The PICC enters the ACTIVE* State when it is selected with its complete UID.
+     * 
+     * Not used though
      */
     RC522_PICC_STATE_READY_H,
 
@@ -145,6 +149,7 @@ typedef struct
     uint8_t sak;
     rc522_picc_type_t type;
     rc522_picc_state_t state;
+    uint32_t last_seen;
 } rc522_picc_t;
 
 typedef struct

--- a/include/rc522_picc.h
+++ b/include/rc522_picc.h
@@ -66,7 +66,7 @@ typedef enum
      * this state to get the complete UID.
      *
      * The PICC enters the ACTIVE State when it is selected with its complete UID.
-     * 
+     *
      * Not used though
      */
     RC522_PICC_STATE_READY,
@@ -101,7 +101,7 @@ typedef enum
      * Cascade levels are handled inside this state to get complete UID.
      *
      * The PICC enters the ACTIVE* State when it is selected with its complete UID.
-     * 
+     *
      * Not used though
      */
     RC522_PICC_STATE_READY_H,

--- a/internal/rc522_types_internal.h
+++ b/internal/rc522_types_internal.h
@@ -5,6 +5,7 @@
 #include <esp_bit_defs.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
+#include "sdkconfig.h"
 #include "rc522_types.h"
 #include "rc522_picc.h"
 
@@ -13,6 +14,8 @@ extern "C" {
 #endif
 
 #define RC522_LOG_TAG "rc522"
+
+#define RC522_PICC_SLOT_COUNT CONFIG_RC522_PICC_SLOT_COUNT
 
 #define RC522_POLL_INTERVAL_MS_DEFAULT (120)
 #define RC522_POLL_INTERVAL_MS_MIN     (50)
@@ -38,7 +41,7 @@ struct rc522
     TaskHandle_t task_handle;             /*<! Handle of task */
     esp_event_loop_handle_t event_handle; /*<! Handle of event loop */
     rc522_state_t state;                  /*<! Current state */
-    rc522_picc_t picc;
+    rc522_picc_t picc[RC522_PICC_SLOT_COUNT];
     EventGroupHandle_t bits;
 };
 

--- a/src/rc522.c
+++ b/src/rc522.c
@@ -283,13 +283,14 @@ void rc522_task(void *arg)
                         scan_known_remaining = 0;
                         continue;
                     }
-                } else {
+                }
+                else {
                     ret = rc522_picc_reqa(rc522, &atqa);
                     if (ret != ESP_OK) {
                         break;
                     }
                 }
-                
+
                 uint8_t sak;
                 ret = rc522_picc_select(rc522, &uid, &sak, uid.length);
                 if (ret != ESP_OK) {
@@ -320,7 +321,8 @@ void rc522_task(void *arg)
                     rc522_picc_set_state(rc522, &rc522->picc[known_index], RC522_PICC_STATE_ACTIVE_H, true);
                     rc522_picc_halta(rc522, &rc522->picc[known_index]);
                     rc522_picc_set_state(rc522, &rc522->picc[known_index], RC522_PICC_STATE_HALT, true);
-                } else {
+                }
+                else {
                     memcpy(&new_picc[new_picc_count].uid, &uid, sizeof(rc522_picc_uid_t));
                     new_picc[new_picc_count].sak = sak;
                     new_picc[new_picc_count].atqa = atqa;
@@ -335,8 +337,7 @@ void rc522_task(void *arg)
 
             // merge new_picc into rc522->picc array, the picc will be ignored if there is no space
             for (int i = 0; i < RC522_PICC_SLOT_COUNT; i++) {
-                if (rc522->picc[i].state != RC522_PICC_STATE_IDLE
-                    && !known_present[i]
+                if (rc522->picc[i].state != RC522_PICC_STATE_IDLE && !known_present[i]
                     && rc522->picc[i].last_seen + picc_heartbeat_failure_threshold_ms < rc522_millis()) {
                     rc522_picc_set_state(rc522, &rc522->picc[i], RC522_PICC_STATE_IDLE, true);
                 }

--- a/src/rc522.c
+++ b/src/rc522.c
@@ -122,7 +122,9 @@ esp_err_t rc522_create(const rc522_config_t *config, rc522_handle_t *out_rc522)
     rc522_handle_t rc522 = calloc(1, sizeof(struct rc522));
     ESP_RETURN_ON_FALSE(rc522 != NULL, ESP_ERR_NO_MEM, TAG, "nomem");
 
-    rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_IDLE, false);
+    for (int i = 0; i < RC522_PICC_SLOT_COUNT; i++) {
+        rc522->picc[i].state = RC522_PICC_STATE_IDLE;
+    }
 
     esp_err_t ret = ESP_OK;
 
@@ -211,7 +213,6 @@ void rc522_task(void *arg)
     uint32_t last_poll_ms = 0;
     const uint32_t task_delay_ms = 50;
     const uint32_t picc_heartbeat_failure_threshold_ms = (2 * task_delay_ms);
-    uint32_t picc_heartbeat_failure_at_ms = 0;
     bool mutex_taken = false;
     const uint16_t mutex_take_timeout_ms = 4000;
 
@@ -246,86 +247,104 @@ void rc522_task(void *arg)
         }
 
         bool should_poll = (rc522_millis() - last_poll_ms) > rc522->config->poll_interval_ms;
-
-        if (rc522->picc.state == RC522_PICC_STATE_IDLE || rc522->picc.state == RC522_PICC_STATE_HALT) {
+        if (should_poll) {
             rc522_picc_atqa_desc_t atqa;
-
-            if (rc522->picc.state == RC522_PICC_STATE_IDLE && ((ret = rc522_picc_reqa(rc522, &atqa)) != ESP_OK)) {
-                continue;
-            }
-
-            if (rc522->picc.state == RC522_PICC_STATE_HALT && ((ret = rc522_picc_wupa(rc522, &atqa)) != ESP_OK)) {
-                continue;
-            }
-
-            // card is present
-            rc522->picc.atqa = atqa;
-
-            if (rc522->picc.state == RC522_PICC_STATE_IDLE) {
-                rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_READY, true);
-            }
-            else if (rc522->picc.state == RC522_PICC_STATE_HALT) {
-                rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_READY_H, true);
-            }
-        }
-
-        if (should_poll
-            && (rc522->picc.state == RC522_PICC_STATE_READY || rc522->picc.state == RC522_PICC_STATE_READY_H)) {
-            rc522_picc_uid_t uid;
-            uint8_t sak;
-
-            ret = rc522_picc_select(rc522, &uid, &sak, false);
-            last_poll_ms = rc522_millis();
-
-            if (ret != ESP_OK) {
-                if (ret != RC522_ERR_RX_TIMEOUT && ret != RC522_ERR_INVALID_ATQA && ret != RC522_ERR_INVALID_SAK) {
-                    RC522_LOGW("select failed (err=%04" RC522_X ")", ret);
+            bool known_present[RC522_PICC_SLOT_COUNT] = { false };
+            uint8_t scan_known_remaining = 0;
+            for (int i = 0; i < RC522_PICC_SLOT_COUNT; i++) {
+                if (rc522->picc[i].state != RC522_PICC_STATE_IDLE) {
+                    scan_known_remaining++;
                 }
-                else {
-                    RC522_LOGD("select failed (err=%04" RC522_X ")", ret);
+            }
+
+            rc522_picc_t new_picc[RC522_PICC_SLOT_COUNT];
+            uint8_t new_picc_count = 0;
+            for (int i = 0; i < RC522_PICC_SLOT_COUNT; i++) {
+                new_picc[i].state = RC522_PICC_STATE_IDLE;
+            }
+
+            for (;;) {
+                if (new_picc_count >= RC522_PICC_SLOT_COUNT) {
+                    break;
                 }
 
-                rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_IDLE, true);
-                continue;
+                rc522_picc_uid_t uid = { .length = 0 };
+                if (scan_known_remaining) {
+                    // find the next known picc uid to select
+                    for (int i = scan_known_remaining - 1; i >= 0; i--) {
+                        if (rc522->picc[i].state != RC522_PICC_STATE_IDLE) {
+                            memcpy(&uid, &rc522->picc[i].uid, sizeof(rc522_picc_uid_t));
+                            break;
+                        }
+                    }
+                    scan_known_remaining--;
+                    ret = rc522_picc_wupa(rc522, &atqa);
+                    if (ret != ESP_OK) {
+                        scan_known_remaining = 0;
+                        continue;
+                    }
+                } else {
+                    ret = rc522_picc_reqa(rc522, &atqa);
+                    if (ret != ESP_OK) {
+                        break;
+                    }
+                }
+                
+                uint8_t sak;
+                ret = rc522_picc_select(rc522, &uid, &sak, uid.length);
+                if (ret != ESP_OK) {
+                    continue;
+                }
+
+                int8_t known_index = -1;
+                for (int i = 0; i < RC522_PICC_SLOT_COUNT; i++) {
+                    if (rc522->picc[i].state != RC522_PICC_STATE_IDLE) {
+                        if (rc522->picc[i].uid.length == uid.length
+                            && memcmp(rc522->picc[i].uid.value, uid.value, uid.length) == 0) {
+                            known_index = i;
+                            break;
+                        }
+                    }
+                }
+
+                if (known_index >= 0) {
+                    if (known_present[known_index]) {
+                        // already processed
+                        rc522_picc_halta(rc522, &rc522->picc[known_index]);
+                        continue;
+                    }
+                    known_present[known_index] = true;
+                    rc522->picc[known_index].sak = sak;
+                    rc522->picc[known_index].atqa = atqa;
+                    rc522->picc[known_index].last_seen = rc522_millis();
+                    rc522_picc_set_state(rc522, &rc522->picc[known_index], RC522_PICC_STATE_ACTIVE_H, true);
+                    rc522_picc_halta(rc522, &rc522->picc[known_index]);
+                    rc522_picc_set_state(rc522, &rc522->picc[known_index], RC522_PICC_STATE_HALT, true);
+                } else {
+                    memcpy(&new_picc[new_picc_count].uid, &uid, sizeof(rc522_picc_uid_t));
+                    new_picc[new_picc_count].sak = sak;
+                    new_picc[new_picc_count].atqa = atqa;
+                    new_picc[new_picc_count].type = rc522_picc_get_type(&new_picc[new_picc_count]);
+                    new_picc[new_picc_count].last_seen = rc522_millis();
+                    rc522_picc_set_state(rc522, &new_picc[new_picc_count], RC522_PICC_STATE_ACTIVE, true);
+                    rc522_picc_halta(rc522, &new_picc[new_picc_count]);
+                    rc522_picc_set_state(rc522, &new_picc[new_picc_count], RC522_PICC_STATE_HALT, true);
+                    new_picc_count++;
+                }
             }
 
-            memcpy(&rc522->picc.uid, &uid, sizeof(rc522_picc_uid_t));
-            rc522->picc.sak = sak;
-            rc522->picc.type = rc522_picc_get_type(&rc522->picc);
-
-            if (rc522->picc.state == RC522_PICC_STATE_READY) {
-                rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_ACTIVE, true);
+            // merge new_picc into rc522->picc array, the picc will be ignored if there is no space
+            for (int i = 0; i < RC522_PICC_SLOT_COUNT; i++) {
+                if (rc522->picc[i].state != RC522_PICC_STATE_IDLE
+                    && !known_present[i]
+                    && rc522->picc[i].last_seen + picc_heartbeat_failure_threshold_ms < rc522_millis()) {
+                    rc522_picc_set_state(rc522, &rc522->picc[i], RC522_PICC_STATE_IDLE, true);
+                }
+                if (rc522->picc[i].state == RC522_PICC_STATE_IDLE && new_picc_count) {
+                    memcpy(&rc522->picc[i], &new_picc[new_picc_count - 1], sizeof(rc522_picc_t));
+                    new_picc_count--;
+                }
             }
-            else if (rc522->picc.state == RC522_PICC_STATE_READY_H) {
-                rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_ACTIVE_H, true);
-            }
-
-            picc_heartbeat_failure_at_ms = 0;
-
-            continue;
-        }
-
-        if (rc522->picc.state == RC522_PICC_STATE_ACTIVE || rc522->picc.state == RC522_PICC_STATE_ACTIVE_H) {
-            if (picc_heartbeat_failure_at_ms != 0
-                && ((rc522_millis() - picc_heartbeat_failure_at_ms) > picc_heartbeat_failure_threshold_ms)) {
-                picc_heartbeat_failure_at_ms = 0;
-                rc522_picc_set_state(rc522, &rc522->picc, RC522_PICC_STATE_IDLE, true);
-                continue;
-            }
-
-            if ((ret = rc522_picc_heartbeat(rc522, &rc522->picc, NULL, NULL)) == ESP_OK) {
-                picc_heartbeat_failure_at_ms = 0;
-            }
-            else if (picc_heartbeat_failure_at_ms == 0) {
-                picc_heartbeat_failure_at_ms = rc522_millis();
-            }
-
-            if (ret != ESP_OK) {
-                RC522_LOGD("heartbeat failed (err=%04" RC522_X ")", ret);
-            }
-
-            // card is still in the field
-            continue;
         }
     }
 


### PR DESCRIPTION
This PR introduces comprehensive support for scanning and managing multiple RFID tags simultaneously on a single RC522 scanner. The refactoring replaces the previous single-tag limitation with a configurable multi-slot system that can handle multiple tags concurrently.

## **BREAKING: Enhanced State Change Event Behavior**

- **Previous behavior**: State change events were only triggered when tags were first detected (placed) or removed
- **New behavior**: State change events are now triggered on **every scan cycle** for all active tags
  - All detected tags are activated (`RC522_PICC_STATE_ACTIVE` or `RC522_PICC_STATE_ACTIVE_H`) and generate state change events during each polling cycle
  - `RC522_PICC_STATE_READY` and `RC522_PICC_STATE_READY_H` are not used currently cause we don't know which one was ready.
  - Applications can now perform operations on tags during any scan cycle, not just during initial detection
