### PR TITLE
Add gain configuration support

### DIFF
--- a/include/rc522_pcd.h
+++ b/include/rc522_pcd.h
@@ -6,6 +6,8 @@
 extern "C" {
 #endif
 
+esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rc522_pcd.h
+++ b/include/rc522_pcd.h
@@ -6,6 +6,26 @@
 extern "C" {
 #endif
 
+enum // RC522_PCD_RF_CFG_REG
+{
+    RC522_PCD_RX_GAIN_2_BIT = BIT6,
+    RC522_PCD_RX_GAIN_1_BIT = BIT5,
+    RC522_PCD_RX_GAIN_0_BIT = BIT4,
+};
+
+/**
+ * Receiver (antenna) gain
+ */
+typedef enum
+{
+    RC522_PCD_18_DB_RX_GAIN = (RC522_PCD_RX_GAIN_1_BIT),                                                     /* 18 dB */
+    RC522_PCD_23_DB_RX_GAIN = (RC522_PCD_RX_GAIN_1_BIT | RC522_PCD_RX_GAIN_0_BIT),                           /* 23 dB */
+    RC522_PCD_33_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT),                                                     /* 33 dB */
+    RC522_PCD_38_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT | RC522_PCD_RX_GAIN_0_BIT),                           /* 38 dB */
+    RC522_PCD_43_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT | RC522_PCD_RX_GAIN_1_BIT),                           /* 43 dB */
+    RC522_PCD_48_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT | RC522_PCD_RX_GAIN_1_BIT | RC522_PCD_RX_GAIN_0_BIT), /* 48 dB */
+} rc522_pcd_rx_gain_t;
+
 esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain);
 
 #ifdef __cplusplus

--- a/include/rc522_types.h
+++ b/include/rc522_types.h
@@ -47,6 +47,19 @@ typedef enum
     RC522_EVENT_PICC_STATE_CHANGED,
 } rc522_event_t;
 
+/**
+ * Receiver (antenna) gain
+ */
+typedef enum
+{
+    RC522_PCD_18_DB_RX_GAIN = 0x20, /* 18 dB */
+    RC522_PCD_23_DB_RX_GAIN = 0x30, /* 23 dB */
+    RC522_PCD_33_DB_RX_GAIN = 0x40, /* 33 dB */
+    RC522_PCD_38_DB_RX_GAIN = 0x50, /* 38 dB */
+    RC522_PCD_43_DB_RX_GAIN = 0x60, /* 43 dB */
+    RC522_PCD_48_DB_RX_GAIN = 0x70, /* 48 dB */
+} rc522_pcd_rx_gain_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rc522_types.h
+++ b/include/rc522_types.h
@@ -47,19 +47,6 @@ typedef enum
     RC522_EVENT_PICC_STATE_CHANGED,
 } rc522_event_t;
 
-/**
- * Receiver (antenna) gain
- */
-typedef enum
-{
-    RC522_PCD_18_DB_RX_GAIN = 0x20, /* 18 dB */
-    RC522_PCD_23_DB_RX_GAIN = 0x30, /* 23 dB */
-    RC522_PCD_33_DB_RX_GAIN = 0x40, /* 33 dB */
-    RC522_PCD_38_DB_RX_GAIN = 0x50, /* 38 dB */
-    RC522_PCD_43_DB_RX_GAIN = 0x60, /* 43 dB */
-    RC522_PCD_48_DB_RX_GAIN = 0x70, /* 48 dB */
-} rc522_pcd_rx_gain_t;
-
 #ifdef __cplusplus
 }
 #endif

--- a/internal/rc522_pcd_internal.h
+++ b/internal/rc522_pcd_internal.h
@@ -233,26 +233,6 @@ enum // RC522_PCD_TX_CONTROL_REG
     RC522_PCD_TX1_RF_EN_BIT = BIT0,
 };
 
-enum // RC522_PCD_RF_CFG_REG
-{
-    RC522_PCD_RX_GAIN_2_BIT = BIT6,
-    RC522_PCD_RX_GAIN_1_BIT = BIT5,
-    RC522_PCD_RX_GAIN_0_BIT = BIT4,
-};
-
-/**
- * Receiver (antenna) gain
- */
-typedef enum
-{
-    RC522_PCD_18_DB_RX_GAIN = (RC522_PCD_RX_GAIN_1_BIT),                                                     /* 18 dB */
-    RC522_PCD_23_DB_RX_GAIN = (RC522_PCD_RX_GAIN_1_BIT | RC522_PCD_RX_GAIN_0_BIT),                           /* 23 dB */
-    RC522_PCD_33_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT),                                                     /* 33 dB */
-    RC522_PCD_38_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT | RC522_PCD_RX_GAIN_0_BIT),                           /* 38 dB */
-    RC522_PCD_43_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT | RC522_PCD_RX_GAIN_1_BIT),                           /* 43 dB */
-    RC522_PCD_48_DB_RX_GAIN = (RC522_PCD_RX_GAIN_2_BIT | RC522_PCD_RX_GAIN_1_BIT | RC522_PCD_RX_GAIN_0_BIT), /* 48 dB */
-} rc522_pcd_rx_gain_t;
-
 typedef enum
 {
     /**

--- a/src/rc522_pcd.c
+++ b/src/rc522_pcd.c
@@ -150,9 +150,7 @@ inline static esp_err_t rc522_pcd_set_timer_reload_value(const rc522_handle_t rc
 
 inline esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain)
 {
-    RC522_RETURN_ON_ERROR(rc522_pcd_set_bits(rc522, RC522_PCD_RF_CFG_REG, (gain & 0x70)));
-
-    return ESP_OK;
+    return rc522_pcd_set_bits(rc522, RC522_PCD_RF_CFG_REG, (gain & 0x70));
 }
 
 esp_err_t rc522_pcd_init(const rc522_handle_t rc522)

--- a/src/rc522_pcd.c
+++ b/src/rc522_pcd.c
@@ -148,9 +148,12 @@ inline static esp_err_t rc522_pcd_set_timer_reload_value(const rc522_handle_t rc
     return ESP_OK;
 }
 
-inline static esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain)
+esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain)
 {
-    return rc522_pcd_set_bits(rc522, RC522_PCD_RF_CFG_REG, gain);
+    RC522_RETURN_ON_ERROR(rc522_pcd_clear_bits(rc522, RC522_PCD_RF_CFG_REG, 0x70));
+    RC522_RETURN_ON_ERROR(rc522_pcd_set_bits(rc522, RC522_PCD_RF_CFG_REG, (gain & 0x70)));
+
+    return ESP_OK;
 }
 
 esp_err_t rc522_pcd_init(const rc522_handle_t rc522)
@@ -185,6 +188,9 @@ esp_err_t rc522_pcd_init(const rc522_handle_t rc522)
 
     // Enable the antenna driver pins TX1 and TX2 (they were disabled by the reset)
     RC522_RETURN_ON_ERROR(rc522_pcd_tx_enable(rc522));
+
+    // Set default antenna gain
+    RC522_RETURN_ON_ERROR(rc522_pcd_write(rc522, RC522_PCD_RF_CFG_REG, RC522_PCD_33_DB_RX_GAIN));
 
     rc522_pcd_firmware_t fw;
     ESP_RETURN_ON_ERROR(rc522_pcd_firmware(rc522, &fw), TAG, "read fw version failed");

--- a/src/rc522_pcd.c
+++ b/src/rc522_pcd.c
@@ -148,9 +148,8 @@ inline static esp_err_t rc522_pcd_set_timer_reload_value(const rc522_handle_t rc
     return ESP_OK;
 }
 
-esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain)
+inline esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain)
 {
-    RC522_RETURN_ON_ERROR(rc522_pcd_clear_bits(rc522, RC522_PCD_RF_CFG_REG, 0x70));
     RC522_RETURN_ON_ERROR(rc522_pcd_set_bits(rc522, RC522_PCD_RF_CFG_REG, (gain & 0x70)));
 
     return ESP_OK;
@@ -188,9 +187,6 @@ esp_err_t rc522_pcd_init(const rc522_handle_t rc522)
 
     // Enable the antenna driver pins TX1 and TX2 (they were disabled by the reset)
     RC522_RETURN_ON_ERROR(rc522_pcd_tx_enable(rc522));
-
-    // Set default antenna gain
-    RC522_RETURN_ON_ERROR(rc522_pcd_write(rc522, RC522_PCD_RF_CFG_REG, RC522_PCD_33_DB_RX_GAIN));
 
     rc522_pcd_firmware_t fw;
     ESP_RETURN_ON_ERROR(rc522_pcd_firmware(rc522, &fw), TAG, "read fw version failed");

--- a/src/rc522_pcd.c
+++ b/src/rc522_pcd.c
@@ -150,7 +150,7 @@ inline static esp_err_t rc522_pcd_set_timer_reload_value(const rc522_handle_t rc
 
 inline esp_err_t rc522_pcd_set_rx_gain(const rc522_handle_t rc522, rc522_pcd_rx_gain_t gain)
 {
-    return rc522_pcd_set_bits(rc522, RC522_PCD_RF_CFG_REG, (gain & 0x70));
+    return rc522_pcd_set_bits(rc522, RC522_PCD_RF_CFG_REG, gain);
 }
 
 esp_err_t rc522_pcd_init(const rc522_handle_t rc522)


### PR DESCRIPTION
Added gain configuration support based on issue #99, the receiver gain can be setup after `rc522_start(scanner)` by calling `rc522_pcd_set_rx_gain(scanner, RC522_PCD_48_DB_RX_GAIN)`.